### PR TITLE
Fix subscription of long topic names

### DIFF
--- a/client/src/basic/BasicClient.h
+++ b/client/src/basic/BasicClient.h
@@ -2318,8 +2318,13 @@ private:
             msg.field_topicId().field().value() = iter->m_topicId;
         }
         else {
-            msg.field_flags().field_topicId().value() = mqttsn::protocol::field::TopicIdTypeVal::Name;
+            msg.field_flags().field_topicId().value() = mqttsn::protocol::field::TopicIdTypeVal::Normal;
             msg.field_topicName().field().value() = op->m_topic;
+            if(strlen(op->m_topic) <= 2 && strpbrk(op->m_topic, "+#") == nullptr) {
+                msg.field_flags().field_topicId().value() = mqttsn::protocol::field::TopicIdTypeVal::Name;
+                uint16_t topicId = (static_cast<uint16_t>(op->m_topic[0]) << 8U) | op->m_topic[1];
+                updateRegInfo(op->m_topic, 2, topicId, true);
+            }
         }
 
         msg.field_flags().field_qos().value() = details::translateQosValue(op->m_qos);
@@ -2383,13 +2388,17 @@ private:
 
         UnsubscribeMsg msg;
 
-        if (op->m_topicId != 0U) {
+        if (op->m_topicId != 0U && strlen(op->m_topic) == 0) {
             msg.field_flags().field_topicId().value() = mqttsn::protocol::field::TopicIdTypeVal::Normal;
             msg.field_topicId().field().value() = iter->m_topicId;
         }
         else {
-            msg.field_flags().field_topicId().value() = mqttsn::protocol::field::TopicIdTypeVal::Name;
+            msg.field_flags().field_topicId().value() = mqttsn::protocol::field::TopicIdTypeVal::Normal;
             msg.field_topicName().field().value() = op->m_topic;
+            if(strlen(op->m_topic) <= 2 && strpbrk(op->m_topic, "+#") == nullptr) {
+                msg.field_flags().field_topicId().value() = mqttsn::protocol::field::TopicIdTypeVal::Name;
+            }
+            op->m_topicId = 0;
         }
 
         msg.field_msgId().value() = op->m_msgId;

--- a/protocol/include/mqttsn/protocol/message/SubUnsubBase.h
+++ b/protocol/include/mqttsn/protocol/message/SubUnsubBase.h
@@ -131,6 +131,11 @@ public:
             expectedTopicIdMode = comms::field::OptionalMode::Missing;
             expectedTopicNameMode = comms::field::OptionalMode::Exists;
         }
+        else if (field_flags().field_topicId().value() == field::TopicIdTypeVal::Normal &&
+                field_topicName().field().value().size()) {
+            expectedTopicIdMode = comms::field::OptionalMode::Missing;
+            expectedTopicNameMode = comms::field::OptionalMode::Exists;
+        }
 
         bool refreshed = false;
         if (field_topicId().getMode() != expectedTopicIdMode) {


### PR DESCRIPTION
Hi,
If one subscribe a topic with more than 2 characters length, the wrong flags are used and it is subscribed as short topic name. This fix checks if a topic name length is more than 2 characters or includes wildcards and uses TopicIdTypeVal::Normal in this case. The MQTTSN spec states that it is not useful to subscribe short topic names with wildcards, they are always handled like long topic names.

Also it registers short topic names in RegInfo, so that we can receive messages, otherwise 
a PUBACK with invalid topic id flag was returned.

The same was applied to unsubscribe. Since I could not unsubscribe topics by ID that were subscribed by name, I had to reset the topic id if a topic name is available to not trigger the asserts.

I thinks this could not merged like this, since I did not fix the tests and some other issues:
 * there is no check that short topic names are fixed length (2 bytes) as expected in the spec
 * not working unsubcribe by topic id if subscribed by id, this could be a issue in the paho gateway. I could not get your gateway to work unfortunately.
* we should refactor the added duplicated code if its clear how we want to handle this
* maybe we should rename `mqttsn::protocol::field::TopicIdTypeVal::Name` to `mqttsn::protocol::field::TopicIdTypeVal::Short_Name` to avoid confusion.
